### PR TITLE
🚀 Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+
+# Change Log
+All notable changes to this project will  be documented in this file
+
+## [0.2.1 (20200209)]
+### Added
+- New Changelog file to keep track of updates!
+- JPEG Mime Type
+- `NetswiftError` now conforms to `Equatable`
+
+### Changed
+- Updated Readme to remove some deprecated stuff
+- Renamed `MimeType.plainText` to `MimeType.text`
+
+### Fixed
+- Access control for several classes has been made public
+- Fixed a typo for the `.mailto` Generic Scheme's rawValue
+- Added missing headers in default implementation of `NetswiftRequest.serialise()`
+
+## [0.2.0 (20200117)]
+### Changed
+- Use default SPM Platform requirements
+

--- a/Example/Netswift.xcodeproj/project.pbxproj
+++ b/Example/Netswift.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
 		9FAC014BC6A2251F2634E5D4 /* Pods_Netswift_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 966D5E0EEF61E8A9FF6FB2FC /* Pods_Netswift_Tests.framework */; };
+		E747194E23E17F0E00DF43A0 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = E747194D23E17F0E00DF43A0 /* CHANGELOG.md */; };
 		E74A82E822871B2B0040A59E /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74A82E722871B2B0040A59E /* API.swift */; };
 		E74A82EA2287250F0040A59E /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74A82E92287250F0040A59E /* ViewController.swift */; };
 		E74A82ED2287265E0040A59E /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E74A82EC2287265E0040A59E /* WebKit.framework */; };
@@ -54,6 +55,7 @@
 		966D5E0EEF61E8A9FF6FB2FC /* Pods_Netswift_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Netswift_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3D770EE1CEB1ABECE3B0F16 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		D6F95FCD2D3839E781A6FA32 /* Netswift.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Netswift.podspec; path = ../Netswift.podspec; sourceTree = "<group>"; };
+		E747194D23E17F0E00DF43A0 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		E74A82E722871B2B0040A59E /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		E74A82E92287250F0040A59E /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		E74A82EC2287265E0040A59E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
@@ -154,6 +156,7 @@
 		607FACF51AFB993E008FA782 /* Podspec Metadata */ = {
 			isa = PBXGroup;
 			children = (
+				E747194D23E17F0E00DF43A0 /* CHANGELOG.md */,
 				D6F95FCD2D3839E781A6FA32 /* Netswift.podspec */,
 				B3D770EE1CEB1ABECE3B0F16 /* README.md */,
 				4FECBF8721A4EC6125CB0C49 /* LICENSE */,
@@ -300,6 +303,7 @@
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
+				E747194E23E17F0E00DF43A0 /* CHANGELOG.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		D4E95839098F0A271D58A38838823B17 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
 		D85D631FCD13BE3C54BD8EEB7D237BA8 /* URLRequestExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC300223BA8EE5D5F3FB6041B4E7404 /* URLRequestExtension.swift */; };
 		E4E8C824E5F0116A5809291861205360 /* GenericScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 309A56B6F36611AAF7F74BF14DFC56F5 /* GenericScheme.swift */; };
+		E721EC8323F064090013B6D9 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = E721EC8223F064090013B6D9 /* CHANGELOG.md */; };
 		E74F37B223D0ACDA00763ABA /* NetswiftHTTPPerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74F37B123D0ACDA00763ABA /* NetswiftHTTPPerformer.swift */; };
 		E7F5E80944DECE0638ADD88919E15FB8 /* NetswiftHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E4757FA773B8AB33933ED57BA098E9 /* NetswiftHandler.swift */; };
 		EF348B8EFE9BFFA7D0734A62FCD271CE /* Pods-Netswift_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9040AA413D18BE035A095B93765A3C6E /* Pods-Netswift_Example-dummy.m */; };
@@ -95,6 +96,7 @@
 		C9CADE4B378498B1C6E7416410F71102 /* NetswiftRoute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetswiftRoute.swift; sourceTree = "<group>"; };
 		CF58E4CBDFE59202EAEC431E03812C17 /* Pods-Netswift_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Netswift_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		DB5655BAB32F45EEED0ADCFE5A9B1728 /* HTTPPerformer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HTTPPerformer.swift; sourceTree = "<group>"; };
+		E721EC8223F064090013B6D9 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		E74F37AF23D0A5A000763ABA /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		E74F37B123D0ACDA00763ABA /* NetswiftHTTPPerformer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetswiftHTTPPerformer.swift; path = Sources/Netswift/NetswiftHTTPPerformer.swift; sourceTree = "<group>"; };
 		E8ABA1ECA5F77BFBD5B5E769D377C23B /* NetswiftSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetswiftSession.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 		B4243DDF64089C3707A90FDF0A471C93 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
+				E721EC8223F064090013B6D9 /* CHANGELOG.md */,
 				E8CF9EAB90625D1CC4EE3246EE5EB0B7 /* LICENSE */,
 				F49E8FA86DE715FE59E734D21642E7DF /* Netswift.podspec */,
 				758BB4A73FE39A6C6A19A90060A617A0 /* README.md */,
@@ -420,6 +423,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E721EC8323F064090013B6D9 /* CHANGELOG.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -590,7 +594,7 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 20200117;
+				CURRENT_PROJECT_VERSION = 20200209;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -600,7 +604,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				MODULEMAP_FILE = "Target Support Files/Netswift/Netswift.modulemap";
 				PRODUCT_MODULE_NAME = Netswift;
 				PRODUCT_NAME = Netswift;
@@ -623,7 +627,7 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 20200117;
+				CURRENT_PROJECT_VERSION = 20200209;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -633,7 +637,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				MODULEMAP_FILE = "Target Support Files/Netswift/Netswift.modulemap";
 				PRODUCT_MODULE_NAME = Netswift;
 				PRODUCT_NAME = Netswift;

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 MrSkwiggs <6209874+MrSkwiggs@users.noreply.github.com>
+Copyright (c) 2019 - 2020 Dorian Grolaux <dorian@skwiggs.dev>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Version](https://img.shields.io/cocoapods/v/Netswift.svg?style=flat)](https://cocoapods.org/pods/Netswift)
 [![License](https://img.shields.io/cocoapods/l/Netswift.svg?style=flat)](https://cocoapods.org/pods/Netswift)
 [![Platform](https://img.shields.io/cocoapods/p/Netswift.svg?style=flat)](https://cocoapods.org/pods/Netswift)
+[![Swift Package Manager](https://img.shields.io/badge/SPM-compatible-brightGreen)](https://swift.org/package-manager/)
 
 ## What
 This library takes care of the heavy lifting required to have a reusable & maintainable networking layer in your Swift apps.
@@ -98,7 +99,7 @@ This time, we don't want to let the compiler add protocol stubs for us just yet.
 
 So for now, let's just add an internal type named `Response` in our extension:
 ```
-struct Response: JSONDecodable {
+struct Response: Decodable {
   let title: String
 }
 ```
@@ -107,7 +108,7 @@ Again, what did we just write?
 
 Well, first of all, we define a type that mimics our endpoint's response structure. That is, an object that contains a member named `title`, which is of type `String`.
 
-Then, we told the compiler that our `Response` type implements the JSONDecodable protocol. This is important for `Netswift`, as it tells it that we expect a JSON object back, for which we can use Swift's generic `JSONDecoder`. This is all done behind the scenes by default implementations. 
+Then, we told the compiler that our `Response` type implements the `Decodable` protocol. `Netswift`,  uses Swift's generic `JSONDecoder`. This is all done behind the scenes by default implementations. 
 
 Yet, the compiler is still unhappy. Now's however a good time to let it 'Add protocol stubs'. We're now given a new function called `serialise`. This is the last part we need to define before we are good to go.
 

--- a/Sources/Netswift/Core/GenericScheme.swift
+++ b/Sources/Netswift/Core/GenericScheme.swift
@@ -16,5 +16,5 @@ public enum GenericScheme: String {
     case https = "https://"
     case ftp = "ftp://"
     case ldap = "ldap://"
-    case mailto = "mailto"
+    case mailto = "mailto:"
 }

--- a/Sources/Netswift/Core/MimeType.swift
+++ b/Sources/Netswift/Core/MimeType.swift
@@ -13,7 +13,7 @@ public enum MimeType: Hashable {
     // MARK: - Text
     
     /// text/plain
-    case plainText
+    case text
     
     /// text/html
     case html
@@ -35,6 +35,11 @@ public enum MimeType: Hashable {
     /// application/octet-stream
     case data
     
+    // MARK: - Image
+    
+    /// image/jpeg
+    case jpg
+    
     // MARK: - Audio
     
     /// audio/mpeg
@@ -53,15 +58,16 @@ public enum MimeType: Hashable {
     /// A custom MIME type.
     case custom(type: String)
     
-    var rawValue: String {
+    public var rawValue: String {
         switch self {
-        case .plainText: return "text/plain"
+        case .text: return "text/plain"
         case .html: return "text/html"
         case .javascript: return "application/javascript"
         case .json: return "application/json"
         case .pdf: return "application/pdf"
         case .zip: return "application/zip"
         case .data: return "application/octet-stream"
+        case .jpg: return "image/jpeg"
         case .mpeg: return "audio/mpeg"
         case .vorbis: return "audio/vorbis"
         case .multipart(let multipart): return multipart.rawValue
@@ -75,14 +81,14 @@ public extension MimeType {
         case form(boundary: String)
         case byteRange(boundary: String)
         
-        var boundary: String {
+        public var boundary: String {
             switch self {
             case .form(let boundary), .byteRange(let boundary):
                 return boundary
             }
         }
         
-        var rawValue: String {
+        public var rawValue: String {
             var value: String = "multipart/"
             
             switch self {

--- a/Sources/Netswift/Core/NetswiftError.swift
+++ b/Sources/Netswift/Core/NetswiftError.swift
@@ -13,13 +13,13 @@ public enum NetswiftError: Swift.Error {
     
     /// The request couldn't be serialised before being sent out
     case requestSerialisationError
-
+    
     /// The request couldn't be processed by the server
     case requestError
-
+    
     /// The server encountered an internal error while processing the request
     case serverError(payload: Data?)
-
+    
     /// The specified resource could not be found on the server (404)
     case resourceNotFound(error: Swift.Error?, payload: Data?)
     
@@ -28,42 +28,77 @@ public enum NetswiftError: Swift.Error {
     
     /// The response returned by the server does not conform to expected type
     case unexpectedResponseError
-
+    
     /// The response returned by the server is empty / nil
     case noResponseError
-
+    
     /// The response's raw data could not be understood
     case responseDecodingError(error: DecodingError, payload: Data?)
-
+    
     /// The response could not be casted to the Request's IncomingType
     case responseCastingError
-
+    
     /// Cannot authenticate the request; authentication needed
     case notAuthenticated
-
+    
     /// The server requires payment data before it can process the request
     case paymentRequired(payload: Data?)
-
+    
     /// The server didn't allow this request for this user
     case notPermitted
-
+    
     /// The request took too long to return. Potential causes include bad network and server issues.
     case timedOut
-
+    
     /// The server does not meet one of the preconditions that the requester put on the request
     case preconditionFailed
-
+    
     /// A request method is not supported for the requested resource
     case methodNotAllowed
-
+    
     /// The user has sent too many requests in a given amount of time
     case tooManyRequests
-
+    
     /// A generic error with a provided error object
     case generic(error: Swift.Error)
-
+    
     /// Fallback error
     case unknown(payload: Data?)
+}
+
+extension NetswiftError: Equatable {
+    public static func == (lhs: NetswiftError, rhs: NetswiftError) -> Bool {
+        switch (lhs, rhs) {
+        case (.requestSerialisationError, .requestSerialisationError),
+             (.requestError, .requestError),
+             (.unexpectedResponseError, .unexpectedResponseError),
+             (.noResponseError, .noResponseError),
+             (.responseCastingError, responseCastingError),
+             (.notAuthenticated, .notAuthenticated),
+             (.notPermitted, .notPermitted),
+             (.timedOut, .timedOut),
+             (.preconditionFailed, .preconditionFailed),
+             (.methodNotAllowed, .methodNotAllowed),
+             (.tooManyRequests, .tooManyRequests):
+            return true
+            
+        case (.serverError(let lhsPayload), .serverError(let rhsPayload)):
+            return lhsPayload == rhsPayload
+            
+        case (.resourceNotFound(let lhsError, let lhsPayload), .resourceNotFound(let rhsError, let rhsPayload)),
+             (.resourceRemoved(let lhsError, let lhsPayload), .resourceRemoved(let rhsError, let rhsPayload)):
+            return lhsError?.localizedDescription == rhsError?.localizedDescription && lhsPayload == rhsPayload
+            
+        case (.responseDecodingError(let lhsError, let lhsPayload), .responseDecodingError(let rhsError, let rhsPayload)):
+            return lhsError.localizedDescription == rhsError.localizedDescription && lhsPayload == rhsPayload
+            
+        case (.paymentRequired(let lhsPayload), .paymentRequired(let rhsPayload)):
+            return lhsPayload == rhsPayload
+            
+        default:
+            return false
+        }
+    }
 }
 
 extension NetswiftError {
@@ -79,7 +114,7 @@ extension NetswiftError {
             return payload
         case let .unknown(payload):
             return payload
-
+            
         case .methodNotAllowed,
              .noResponseError,
              .notAuthenticated,

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -95,6 +95,8 @@ public extension NetswiftRequest where Self: NetswiftRoute {
         headers.append(.contentType(contentType))
         headers.append(.accept(accept))
         
+        request.addHeaders(headers)
+        
         return .success(request)
     }
 }


### PR DESCRIPTION
## [0.2.1 (20200209)]
### Added
- New Changelog file to keep track of updates!
- JPEG Mime Type
- `NetswiftError` now conforms to `Equatable`

### Changed
- Updated Readme to remove some deprecated stuff
- Renamed `MimeType.plainText` to `MimeType.text`

### Fixed
- Access control for several classes has been made public
- Fixed a typo for the `.mailto` Generic Scheme's rawValue
- Added missing headers in default implementation of `NetswiftRequest.serialise()`