### PR TITLE
Netswift error refactor

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Netswift/Core/NetswiftError.swift
+++ b/Sources/Netswift/Core/NetswiftError.swift
@@ -18,71 +18,6 @@ public struct NetswiftError: Swift.Error {
         self.payload = payload
     }
     
-    /**
-     The stage at which the error happened.
-     */
-    public enum Stage {
-        /// The error happened before being performed
-        case send(Send)
-        
-        /// The error happened while being performed
-        case receive(Receive)
-        
-        /// The error happened after it was performed, during internal processing
-        case process(Process)
-        
-        
-        public enum Send {
-            case serialisationFailed
-            
-        }
-        
-        public enum Receive {
-            /// The server encountered an internal error while processing the request
-            case serverError
-            
-            /// The specified resource could not be found on the server (404)
-            case resourceNotFound
-            
-            /// The specified resource has been permanently removed
-            case resourceRemoved
-            
-            /// Cannot authenticate the request; authentication needed
-            case notAuthenticated
-            
-            /// The server requires payment data before it can process the request
-            case paymentRequired
-            
-            /// The server didn't allow this request for this user
-            case notPermitted
-            
-            /// The request took too long to return. Potential causes include bad network and server issues.
-            case timedOut
-            
-            /// The server does not meet one of the preconditions that the requester put on the request
-            case preconditionFailed
-            
-            /// A request method is not supported for the requested resource
-            case methodNotAllowed
-            
-            /// The user has sent too many requests in a given amount of time
-            case tooManyRequests
-        }
-        
-        public enum Process {
-            case decoding(error: DecodingError)
-            
-            /// The response could not be casted to the Request's IncomingType
-            case responseCastingError
-            
-            /// The response returned by the server does not conform to expected type
-            case unexpectedResponse
-            
-            /// The response returned by the server is empty / nil
-            case noResponse
-        }
-    }
-    
     /// All the errors that can be raised while performing HTTP requests
     public enum Category {
         
@@ -96,10 +31,10 @@ public struct NetswiftError: Swift.Error {
         case serverError
         
         /// The specified resource could not be found on the server (404)
-        case resourceNotFound(error: Swift.Error?)
+        case resourceNotFound
         
         /// The specified resource has been permanently removed
-        case resourceRemoved(error: Swift.Error?)
+        case resourceRemoved
         
         /// The response returned by the server does not conform to expected type
         case unexpectedResponseError
@@ -139,43 +74,6 @@ public struct NetswiftError: Swift.Error {
         
         /// Fallback error
         case unknown
-        
-        init?(fromStatusCode statusCode: Int) {
-            switch statusCode {
-            case 200...299:
-                return nil
-                
-            case 400:
-                self = .requestError
-                
-            case 401:
-                self = .notAuthenticated
-                
-            case 402:
-                self = .paymentRequired
-                
-            case 403:
-                self = .notPermitted
-                
-            case 404:
-                self = .resourceNotFound
-                
-            case 405:
-                self = .methodNotAllowed
-                
-            case 412:
-                self = .preconditionFailed
-                
-            case 429:
-                self = .tooManyRequests
-                
-            case 500:
-                self = .serverError
-                
-            default:
-                self = .unknown
-            }
-        }
     }
 }
 
@@ -194,12 +92,10 @@ extension NetswiftError: Equatable {
              (.methodNotAllowed, .methodNotAllowed),
              (.tooManyRequests, .tooManyRequests),
              (.serverError, .serverError),
-             (.paymentRequired, .paymentRequired):
+             (.paymentRequired, .paymentRequired),
+             (.resourceNotFound, .resourceNotFound),
+             (.resourceRemoved, .resourceRemoved):
             return true
-            
-        case (.resourceNotFound(let lhsError), .resourceNotFound(let rhsError)),
-             (.resourceRemoved(let lhsError), .resourceRemoved(let rhsError)):
-            return lhsError?.localizedDescription == rhsError?.localizedDescription
             
         case (.responseDecodingError(let lhsError), .responseDecodingError(let rhsError)):
             return lhsError.localizedDescription == rhsError.localizedDescription

--- a/Sources/Netswift/Core/NetswiftError.swift
+++ b/Sources/Netswift/Core/NetswiftError.swift
@@ -8,92 +8,201 @@
 
 import Foundation
 
-/// All the errors that can be raised while performing HTTP requests
-public enum NetswiftError: Swift.Error {
+public struct NetswiftError: Swift.Error {
     
-    /// The request couldn't be serialised before being sent out
-    case requestSerialisationError
+    public let category: Category
+    public let payload: Data?
     
-    /// The request couldn't be processed by the server
-    case requestError
+    public init(category: Category, payload: Data?) {
+        self.category = category
+        self.payload = payload
+    }
     
-    /// The server encountered an internal error while processing the request
-    case serverError(payload: Data?)
+    /**
+     The stage at which the error happened.
+     */
+    public enum Stage {
+        /// The error happened before being performed
+        case send(Send)
+        
+        /// The error happened while being performed
+        case receive(Receive)
+        
+        /// The error happened after it was performed, during internal processing
+        case process(Process)
+        
+        
+        public enum Send {
+            case serialisationFailed
+            
+        }
+        
+        public enum Receive {
+            /// The server encountered an internal error while processing the request
+            case serverError
+            
+            /// The specified resource could not be found on the server (404)
+            case resourceNotFound
+            
+            /// The specified resource has been permanently removed
+            case resourceRemoved
+            
+            /// Cannot authenticate the request; authentication needed
+            case notAuthenticated
+            
+            /// The server requires payment data before it can process the request
+            case paymentRequired
+            
+            /// The server didn't allow this request for this user
+            case notPermitted
+            
+            /// The request took too long to return. Potential causes include bad network and server issues.
+            case timedOut
+            
+            /// The server does not meet one of the preconditions that the requester put on the request
+            case preconditionFailed
+            
+            /// A request method is not supported for the requested resource
+            case methodNotAllowed
+            
+            /// The user has sent too many requests in a given amount of time
+            case tooManyRequests
+        }
+        
+        public enum Process {
+            case decoding(error: DecodingError)
+            
+            /// The response could not be casted to the Request's IncomingType
+            case responseCastingError
+            
+            /// The response returned by the server does not conform to expected type
+            case unexpectedResponse
+            
+            /// The response returned by the server is empty / nil
+            case noResponse
+        }
+    }
     
-    /// The specified resource could not be found on the server (404)
-    case resourceNotFound(error: Swift.Error?, payload: Data?)
-    
-    /// The specified resource has been permanently removed
-    case resourceRemoved(error: Swift.Error?, payload: Data?)
-    
-    /// The response returned by the server does not conform to expected type
-    case unexpectedResponseError
-    
-    /// The response returned by the server is empty / nil
-    case noResponseError
-    
-    /// The response's raw data could not be understood
-    case responseDecodingError(error: DecodingError, payload: Data?)
-    
-    /// The response could not be casted to the Request's IncomingType
-    case responseCastingError
-    
-    /// Cannot authenticate the request; authentication needed
-    case notAuthenticated
-    
-    /// The server requires payment data before it can process the request
-    case paymentRequired(payload: Data?)
-    
-    /// The server didn't allow this request for this user
-    case notPermitted
-    
-    /// The request took too long to return. Potential causes include bad network and server issues.
-    case timedOut
-    
-    /// The server does not meet one of the preconditions that the requester put on the request
-    case preconditionFailed
-    
-    /// A request method is not supported for the requested resource
-    case methodNotAllowed
-    
-    /// The user has sent too many requests in a given amount of time
-    case tooManyRequests
-    
-    /// A generic error with a provided error object
-    case generic(error: Swift.Error)
-    
-    /// Fallback error
-    case unknown(payload: Data?)
+    /// All the errors that can be raised while performing HTTP requests
+    public enum Category {
+        
+        /// The request couldn't be serialised before being sent out
+        case requestSerialisationError
+        
+        /// The request couldn't be processed by the server
+        case requestError
+        
+        /// The server encountered an internal error while processing the request
+        case serverError
+        
+        /// The specified resource could not be found on the server (404)
+        case resourceNotFound(error: Swift.Error?)
+        
+        /// The specified resource has been permanently removed
+        case resourceRemoved(error: Swift.Error?)
+        
+        /// The response returned by the server does not conform to expected type
+        case unexpectedResponseError
+        
+        /// The response returned by the server is empty / nil
+        case noResponseError
+        
+        /// The response's raw data could not be understood
+        case responseDecodingError(error: DecodingError)
+        
+        /// The response could not be casted to the Request's IncomingType
+        case responseCastingError
+        
+        /// Cannot authenticate the request; authentication needed
+        case notAuthenticated
+        
+        /// The server requires payment data before it can process the request
+        case paymentRequired
+        
+        /// The server didn't allow this request for this user
+        case notPermitted
+        
+        /// The request took too long to return. Potential causes include bad network and server issues.
+        case timedOut
+        
+        /// The server does not meet one of the preconditions that the requester put on the request
+        case preconditionFailed
+        
+        /// A request method is not supported for the requested resource
+        case methodNotAllowed
+        
+        /// The user has sent too many requests in a given amount of time
+        case tooManyRequests
+        
+        /// A generic error with a provided error object
+        case generic(error: Swift.Error)
+        
+        /// Fallback error
+        case unknown
+        
+        init?(fromStatusCode statusCode: Int) {
+            switch statusCode {
+            case 200...299:
+                return nil
+                
+            case 400:
+                self = .requestError
+                
+            case 401:
+                self = .notAuthenticated
+                
+            case 402:
+                self = .paymentRequired
+                
+            case 403:
+                self = .notPermitted
+                
+            case 404:
+                self = .resourceNotFound
+                
+            case 405:
+                self = .methodNotAllowed
+                
+            case 412:
+                self = .preconditionFailed
+                
+            case 429:
+                self = .tooManyRequests
+                
+            case 500:
+                self = .serverError
+                
+            default:
+                self = .unknown
+            }
+        }
+    }
 }
 
 extension NetswiftError: Equatable {
     public static func == (lhs: NetswiftError, rhs: NetswiftError) -> Bool {
-        switch (lhs, rhs) {
+        switch (lhs.category, rhs.category) {
         case (.requestSerialisationError, .requestSerialisationError),
              (.requestError, .requestError),
              (.unexpectedResponseError, .unexpectedResponseError),
              (.noResponseError, .noResponseError),
-             (.responseCastingError, responseCastingError),
+             (.responseCastingError, .responseCastingError),
              (.notAuthenticated, .notAuthenticated),
              (.notPermitted, .notPermitted),
              (.timedOut, .timedOut),
              (.preconditionFailed, .preconditionFailed),
              (.methodNotAllowed, .methodNotAllowed),
-             (.tooManyRequests, .tooManyRequests):
+             (.tooManyRequests, .tooManyRequests),
+             (.serverError, .serverError),
+             (.paymentRequired, .paymentRequired):
             return true
             
-        case (.serverError(let lhsPayload), .serverError(let rhsPayload)):
-            return lhsPayload == rhsPayload
+        case (.resourceNotFound(let lhsError), .resourceNotFound(let rhsError)),
+             (.resourceRemoved(let lhsError), .resourceRemoved(let rhsError)):
+            return lhsError?.localizedDescription == rhsError?.localizedDescription
             
-        case (.resourceNotFound(let lhsError, let lhsPayload), .resourceNotFound(let rhsError, let rhsPayload)),
-             (.resourceRemoved(let lhsError, let lhsPayload), .resourceRemoved(let rhsError, let rhsPayload)):
-            return lhsError?.localizedDescription == rhsError?.localizedDescription && lhsPayload == rhsPayload
-            
-        case (.responseDecodingError(let lhsError, let lhsPayload), .responseDecodingError(let rhsError, let rhsPayload)):
-            return lhsError.localizedDescription == rhsError.localizedDescription && lhsPayload == rhsPayload
-            
-        case (.paymentRequired(let lhsPayload), .paymentRequired(let rhsPayload)):
-            return lhsPayload == rhsPayload
+        case (.responseDecodingError(let lhsError), .responseDecodingError(let rhsError)):
+            return lhsError.localizedDescription == rhsError.localizedDescription
             
         default:
             return false
@@ -101,40 +210,9 @@ extension NetswiftError: Equatable {
     }
 }
 
-extension NetswiftError {
-    public var payload: Data? {
-        switch self {
-        case let .resourceNotFound(_, payload), let .resourceRemoved(_, payload):
-            return payload
-        case let .responseDecodingError(_, payload):
-            return payload
-        case let .serverError(payload):
-            return payload
-        case let .paymentRequired(payload):
-            return payload
-        case let .unknown(payload):
-            return payload
-            
-        case .methodNotAllowed,
-             .noResponseError,
-             .notAuthenticated,
-             .notPermitted,
-             .preconditionFailed,
-             .requestError,
-             .requestSerialisationError,
-             .responseCastingError,
-             .timedOut,
-             .tooManyRequests,
-             .unexpectedResponseError,
-             .generic:
-            return nil
-        }
-    }
-}
-
 extension NetswiftError: CustomDebugStringConvertible {
     public var debugDescription: String {
-        switch self {
+        switch self.category {
         case .requestSerialisationError:
             return "The request couldn't be serialised before being sent out"
         case .requestError:

--- a/Sources/Netswift/Core/NetswiftError.swift
+++ b/Sources/Netswift/Core/NetswiftError.swift
@@ -18,6 +18,11 @@ public struct NetswiftError: Swift.Error {
         self.payload = payload
     }
     
+    public init(_ category: Category) {
+        self.category = category
+        self.payload = nil
+    }
+    
     /// All the errors that can be raised while performing HTTP requests
     public enum Category {
         

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -67,6 +67,16 @@ public protocol NetswiftRequest {
      - returns: A NetswiftResult that either succeeds with a Response object, or fails with a NetswiftError.
      */
     func deserialise(_ incomingData: IncomingType) -> NetswiftResult<Response>
+    
+    
+    /**
+     Tries to intercept and handle an error thrown during the Request's performing.
+     
+     This allows to handle network & related errors directly from within a Request's declaration.
+     - parameter error: The error thrown
+     - note: Returns `.failure(error)` by default
+     */
+    func intercept(_ error: NetswiftError) -> NetswiftResult<Response>
 }
 
 public extension NetswiftRequest {

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -70,7 +70,7 @@ public protocol NetswiftRequest {
     
     
     /**
-     Tries to intercept and handle an error thrown during the Request's performing.
+     Tries to intercept and handle an error thrown while the Request is being performed.
      
      This allows to handle network & related errors directly from within a Request's declaration.
      - parameter error: The error thrown

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -91,6 +91,10 @@ public extension NetswiftRequest {
     var accept: MimeType {
         return .json
     }
+    
+    func intercept(_ error: NetswiftError) -> NetswiftResult<Response> {
+        return .failure(error)
+    }
 }
 
 // MARK: - Convenience Serialising

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -111,9 +111,9 @@ public extension NetswiftRequest where IncomingType == Data, Response: Decodable
             return .success(decodedResponse)
             
         } catch let error as DecodingError {
-            return .failure(.responseDecodingError(error: error, payload: incomingData))
+            return .failure(.init(category: .responseDecodingError(error: error), payload: incomingData))
         } catch {
-            return .failure(.unexpectedResponseError)
+            return .failure(.init(category: .unexpectedResponseError, payload: incomingData))
         }
     }
 }
@@ -121,7 +121,7 @@ public extension NetswiftRequest where IncomingType == Data, Response: Decodable
 public extension NetswiftRequest where IncomingType == Data, Response == String {
     func deserialise(_ incomingData: Data) -> NetswiftResult<Response> {
         guard let string = String(data: incomingData, encoding: .utf8) else {
-            return .failure(.unexpectedResponseError)
+            return .failure(.init(category: .unexpectedResponseError, payload: incomingData))
         }
         return .success(string)
     }
@@ -132,11 +132,11 @@ public extension NetswiftRequest where IncomingType == Data, Response == String 
 /// When the request expects freeform data, decoding is done during deserialisation
 public extension NetswiftRequest where IncomingType == Data {
     func decode(_ data: Data?) -> NetswiftResult<Any> {
-        guard let data = data else {
-            return .failure(.noResponseError)
+        guard let incomingData = data else {
+            return .failure(.init(category: .noResponseError, payload: data))
         }
         
-        return .success(data)
+        return .success(incomingData)
     }
 }
 
@@ -149,6 +149,6 @@ public extension NetswiftRequest {
             return .success(castedObject)
         }
         
-        return .failure(.responseCastingError)
+        return .failure(.init(category: .responseCastingError, payload: any as? Data))
     }
 }

--- a/Sources/Netswift/NetswiftHTTPPerformer.swift
+++ b/Sources/Netswift/NetswiftHTTPPerformer.swift
@@ -51,34 +51,34 @@ open class NetswiftHTTPPerformer: HTTPPerformer {
             return .success(response.data)
 
         case 400:
-            return .failure(.requestError)
+            return .failure(.init(category: .requestError, payload: nil))
 
         case 401:
-            return .failure(.notAuthenticated)
+            return .failure(.init(category: .notAuthenticated, payload: nil))
 
         case 402:
-            return .failure(.paymentRequired(payload: response.data))
+            return .failure(.init(category: .paymentRequired, payload: response.data))
 
         case 403:
-            return .failure(.notPermitted)
+            return .failure(.init(category: .notPermitted, payload: nil))
 
         case 404:
-            return .failure(.resourceNotFound(error: response.error, payload: response.data))
+            return .failure(.init(category: .resourceNotFound, payload: response.data))
 
         case 405:
-            return .failure(.methodNotAllowed)
+            return .failure(.init(category: .methodNotAllowed, payload: nil))
 
         case 412:
-            return .failure(.preconditionFailed)
+            return .failure(.init(category: .preconditionFailed, payload: nil))
 
         case 429:
-            return .failure(.tooManyRequests)
+            return .failure(.init(category: .tooManyRequests, payload: nil))
 
         case 500:
-            return .failure(.serverError(payload: response.data))
+            return .failure(.init(category: .serverError, payload: response.data))
 
         default:
-            return .failure(.unknown(payload: response.data))
+            return .failure(.init(category: .unknown, payload: response.data))
         }
     }
 }

--- a/Sources/Netswift/NetswiftHTTPPerformer.swift
+++ b/Sources/Netswift/NetswiftHTTPPerformer.swift
@@ -27,7 +27,7 @@ public final class NetswiftHTTPPerformer: HTTPPerformer {
         let dispatchGroup = DispatchGroup()
         
         if dispatchGroup.wait(timeout: timeOut) == .timedOut {
-            completion(.failure(.timedOut))
+            completion(.failure(.init(category: .timedOut, payload: nil)))
         }
         
         dispatchGroup.enter()
@@ -41,9 +41,9 @@ public final class NetswiftHTTPPerformer: HTTPPerformer {
     private func validate(_ response: NetswiftHTTPResponse) -> NetswiftResult<Data?> {
         guard let statusCode = response.statusCode else {
             guard let error = response.error else {
-                return .failure(.unknown(payload: response.data))
+                return .failure(.init(category: .unknown, payload: response.data))
             }
-            return .failure(.generic(error: error))
+            return .failure(.init(category: .generic(error: error), payload: nil))
         }
         
         switch statusCode {

--- a/Sources/Netswift/NetswiftHTTPPerformer.swift
+++ b/Sources/Netswift/NetswiftHTTPPerformer.swift
@@ -43,7 +43,7 @@ open class NetswiftHTTPPerformer: HTTPPerformer {
             guard let error = response.error else {
                 return .failure(.init(category: .unknown, payload: response.data))
             }
-            return .failure(.init(category: .generic(error: error), payload: nil))
+            return .failure(.init(category: .generic(error: error), payload: response.data))
         }
         
         switch statusCode {
@@ -51,28 +51,28 @@ open class NetswiftHTTPPerformer: HTTPPerformer {
             return .success(response.data)
 
         case 400:
-            return .failure(.init(category: .requestError, payload: nil))
+            return .failure(.init(category: .requestError, payload: response.data))
 
         case 401:
-            return .failure(.init(category: .notAuthenticated, payload: nil))
+            return .failure(.init(category: .notAuthenticated, payload: response.data))
 
         case 402:
             return .failure(.init(category: .paymentRequired, payload: response.data))
 
         case 403:
-            return .failure(.init(category: .notPermitted, payload: nil))
+            return .failure(.init(category: .notPermitted, payload: response.data))
 
         case 404:
             return .failure(.init(category: .resourceNotFound, payload: response.data))
 
         case 405:
-            return .failure(.init(category: .methodNotAllowed, payload: nil))
+            return .failure(.init(category: .methodNotAllowed, payload: response.data))
 
         case 412:
-            return .failure(.init(category: .preconditionFailed, payload: nil))
+            return .failure(.init(category: .preconditionFailed, payload: response.data))
 
         case 429:
-            return .failure(.init(category: .tooManyRequests, payload: nil))
+            return .failure(.init(category: .tooManyRequests, payload: response.data))
 
         case 500:
             return .failure(.init(category: .serverError, payload: response.data))

--- a/Sources/Netswift/NetswiftPerformer.swift
+++ b/Sources/Netswift/NetswiftPerformer.swift
@@ -20,11 +20,18 @@ open class NetswiftPerformer: NetswiftNetworkPerformer {
         switch request.serialise() {
         case .success(let url):
             return self.requestPerformer.perform(url) { response in
-                let networkResponse = response
-                    .flatMap(request.decode)
-                    .flatMap(request.cast)
-                    .flatMap(request.deserialise)
-                handler(networkResponse)
+                
+                switch response {
+                case .success:
+                    let networkResponse = response
+                        .flatMap(request.decode)
+                        .flatMap(request.cast)
+                        .flatMap(request.deserialise)
+                    handler(networkResponse)
+                    
+                case .failure(let error):
+                    handler(request.intercept(error))
+                }
             }
             
         case .failure(let error):


### PR DESCRIPTION
This refactor turns NetswiftError into a `struct`, rather than an `enum`. 
The main benefit of this change is that it allows to always have a reference to the original network payload data.

Which brings us to the second benefit: `NetswiftRequest` now has an additional handling step which lets it intercept any `NetswiftError` and potentially handle them and still return a valid `Response`. 

This is handy if you use the generic `NetswiftNetworkPerformer` (`Netswift`) and your endpoint uses HTTP status codes for its business logic. When that happened, none of the `NetswiftRequest`'s handling step would ever be called. 