### PR TITLE
🚀 Release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to this project will  be documented in this file
 
 ## Unreleased
+### Changed
 
+### Fixed
+
+## [0.3.0 (20200225)]
 ### Changed
 - `NetswiftError` has been refactored to always keep track of a network task's response payload, if any is available.
 - `NetswiftRequest` are now given a chance to intercept and handle a `NetswiftError` when performed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 # Change Log
 All notable changes to this project will  be documented in this file
 
+## Unreleased
+
+### Changed
+- `NetswiftError` has been refactored to always keep track of a network task's response payload, if any is available.
+- `NetswiftRequest` are now given a chance to intercept and handle a `NetswiftError` when performed.
+
+### Fixed
+- Access control levels for  `NetswiftHTTPPerformer` and `NetswiftPerformer` have been set to `open` to allow for overriding and extending.
+
 ## [0.2.1 (20200209)]
 ### Added
 - New Changelog file to keep track of updates!

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -594,7 +594,7 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 20200209;
+				CURRENT_PROJECT_VERSION = 20200225;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -604,7 +604,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.3.0;
 				MODULEMAP_FILE = "Target Support Files/Netswift/Netswift.modulemap";
 				PRODUCT_MODULE_NAME = Netswift;
 				PRODUCT_NAME = Netswift;
@@ -627,7 +627,7 @@
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 20200209;
+				CURRENT_PROJECT_VERSION = 20200225;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -637,7 +637,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.2.1;
+				MARKETING_VERSION = 0.3.0;
 				MODULEMAP_FILE = "Target Support Files/Netswift/Netswift.modulemap";
 				PRODUCT_MODULE_NAME = Netswift;
 				PRODUCT_NAME = Netswift;

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ Now's the moment we've been waiting for: sending out our request!
 
 All we need to do is to actually perform our request. To do so, we can use an instance of the default `Netswift` class. All we need to do is call this:
 ```
-Netswift().perform(MyAPI.helloWorld) { result in 
-  guard let response = result.value else {
-    if let error = result.error {
-      print(error)
-    }
-    return
+Netswift().perform(MyAPI.helloWorld) { result in
+  switch result {
+  case .failure(let error):
+    // Our request failed: we can use the error to debug it
+    print(error)
+    
+  case .success(let value):
+    // Our request succeeded: we now have an object of type MyAPI.Response available to use
+    print(value.title)
   }
-  
-  // Our request succeeded: we now have an object of type MyAPI.Response available to use
-  print(response.title)
 }
 ```
 
@@ -153,12 +153,12 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ## Installation
 
-Netswift is available through [CocoaPods](https://cocoapods.org). To install
-it, simply add the following line to your Podfile:
-
+Netswift is available through:
+- [CocoaPods](https://cocoapods.org): To install it, simply add the following line to your Podfile
 ```ruby
 pod 'Netswift'
 ```
+- [Swift Package Manager](https://github.com/MrSkwiggs/Netswift): To install it, simply search for it through XCode's integrated package navigator
 
 ## Author
 

--- a/Sources/Netswift/Core/NetswiftError.swift
+++ b/Sources/Netswift/Core/NetswiftError.swift
@@ -8,92 +8,102 @@
 
 import Foundation
 
-/// All the errors that can be raised while performing HTTP requests
-public enum NetswiftError: Swift.Error {
+public struct NetswiftError: Swift.Error {
     
-    /// The request couldn't be serialised before being sent out
-    case requestSerialisationError
+    public let category: Category
+    public let payload: Data?
     
-    /// The request couldn't be processed by the server
-    case requestError
+    public init(category: Category, payload: Data?) {
+        self.category = category
+        self.payload = payload
+    }
     
-    /// The server encountered an internal error while processing the request
-    case serverError(payload: Data?)
+    public init(_ category: Category) {
+        self.category = category
+        self.payload = nil
+    }
     
-    /// The specified resource could not be found on the server (404)
-    case resourceNotFound(error: Swift.Error?, payload: Data?)
-    
-    /// The specified resource has been permanently removed
-    case resourceRemoved(error: Swift.Error?, payload: Data?)
-    
-    /// The response returned by the server does not conform to expected type
-    case unexpectedResponseError
-    
-    /// The response returned by the server is empty / nil
-    case noResponseError
-    
-    /// The response's raw data could not be understood
-    case responseDecodingError(error: DecodingError, payload: Data?)
-    
-    /// The response could not be casted to the Request's IncomingType
-    case responseCastingError
-    
-    /// Cannot authenticate the request; authentication needed
-    case notAuthenticated
-    
-    /// The server requires payment data before it can process the request
-    case paymentRequired(payload: Data?)
-    
-    /// The server didn't allow this request for this user
-    case notPermitted
-    
-    /// The request took too long to return. Potential causes include bad network and server issues.
-    case timedOut
-    
-    /// The server does not meet one of the preconditions that the requester put on the request
-    case preconditionFailed
-    
-    /// A request method is not supported for the requested resource
-    case methodNotAllowed
-    
-    /// The user has sent too many requests in a given amount of time
-    case tooManyRequests
-    
-    /// A generic error with a provided error object
-    case generic(error: Swift.Error)
-    
-    /// Fallback error
-    case unknown(payload: Data?)
+    /// All the errors that can be raised while performing HTTP requests
+    public enum Category {
+        
+        /// The request couldn't be serialised before being sent out
+        case requestSerialisationError
+        
+        /// The request couldn't be processed by the server
+        case requestError
+        
+        /// The server encountered an internal error while processing the request
+        case serverError
+        
+        /// The specified resource could not be found on the server (404)
+        case resourceNotFound
+        
+        /// The specified resource has been permanently removed
+        case resourceRemoved
+        
+        /// The response returned by the server does not conform to expected type
+        case unexpectedResponseError
+        
+        /// The response returned by the server is empty / nil
+        case noResponseError
+        
+        /// The response's raw data could not be understood
+        case responseDecodingError(error: DecodingError)
+        
+        /// The response could not be casted to the Request's IncomingType
+        case responseCastingError
+        
+        /// Cannot authenticate the request; authentication needed
+        case notAuthenticated
+        
+        /// The server requires payment data before it can process the request
+        case paymentRequired
+        
+        /// The server didn't allow this request for this user
+        case notPermitted
+        
+        /// The request took too long to return. Potential causes include bad network and server issues.
+        case timedOut
+        
+        /// The server does not meet one of the preconditions that the requester put on the request
+        case preconditionFailed
+        
+        /// A request method is not supported for the requested resource
+        case methodNotAllowed
+        
+        /// The user has sent too many requests in a given amount of time
+        case tooManyRequests
+        
+        /// A generic error with a provided error object
+        case generic(error: Swift.Error)
+        
+        /// Fallback error
+        case unknown
+    }
 }
 
 extension NetswiftError: Equatable {
     public static func == (lhs: NetswiftError, rhs: NetswiftError) -> Bool {
-        switch (lhs, rhs) {
+        switch (lhs.category, rhs.category) {
         case (.requestSerialisationError, .requestSerialisationError),
              (.requestError, .requestError),
              (.unexpectedResponseError, .unexpectedResponseError),
              (.noResponseError, .noResponseError),
-             (.responseCastingError, responseCastingError),
+             (.responseCastingError, .responseCastingError),
              (.notAuthenticated, .notAuthenticated),
              (.notPermitted, .notPermitted),
              (.timedOut, .timedOut),
              (.preconditionFailed, .preconditionFailed),
              (.methodNotAllowed, .methodNotAllowed),
-             (.tooManyRequests, .tooManyRequests):
+             (.tooManyRequests, .tooManyRequests),
+             (.serverError, .serverError),
+             (.paymentRequired, .paymentRequired),
+             (.resourceNotFound, .resourceNotFound),
+             (.resourceRemoved, .resourceRemoved):
             return true
             
-        case (.serverError(let lhsPayload), .serverError(let rhsPayload)):
-            return lhsPayload == rhsPayload
-            
-        case (.resourceNotFound(let lhsError, let lhsPayload), .resourceNotFound(let rhsError, let rhsPayload)),
-             (.resourceRemoved(let lhsError, let lhsPayload), .resourceRemoved(let rhsError, let rhsPayload)):
-            return lhsError?.localizedDescription == rhsError?.localizedDescription && lhsPayload == rhsPayload
-            
-        case (.responseDecodingError(let lhsError, let lhsPayload), .responseDecodingError(let rhsError, let rhsPayload)):
-            return lhsError.localizedDescription == rhsError.localizedDescription && lhsPayload == rhsPayload
-            
-        case (.paymentRequired(let lhsPayload), .paymentRequired(let rhsPayload)):
-            return lhsPayload == rhsPayload
+        case (.responseDecodingError(let lhsError), .responseDecodingError(let rhsError)):
+            return lhsError.localizedDescription == rhsError.localizedDescription
             
         default:
             return false
@@ -101,40 +111,9 @@ extension NetswiftError: Equatable {
     }
 }
 
-extension NetswiftError {
-    public var payload: Data? {
-        switch self {
-        case let .resourceNotFound(_, payload), let .resourceRemoved(_, payload):
-            return payload
-        case let .responseDecodingError(_, payload):
-            return payload
-        case let .serverError(payload):
-            return payload
-        case let .paymentRequired(payload):
-            return payload
-        case let .unknown(payload):
-            return payload
-            
-        case .methodNotAllowed,
-             .noResponseError,
-             .notAuthenticated,
-             .notPermitted,
-             .preconditionFailed,
-             .requestError,
-             .requestSerialisationError,
-             .responseCastingError,
-             .timedOut,
-             .tooManyRequests,
-             .unexpectedResponseError,
-             .generic:
-            return nil
-        }
-    }
-}
-
 extension NetswiftError: CustomDebugStringConvertible {
     public var debugDescription: String {
-        switch self {
+        switch self.category {
         case .requestSerialisationError:
             return "The request couldn't be serialised before being sent out"
         case .requestError:

--- a/Sources/Netswift/NetswiftHTTPPerformer.swift
+++ b/Sources/Netswift/NetswiftHTTPPerformer.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A generic HTTP Performer. For detailed doc please refer to HTTPPerformer protocol
-public final class NetswiftHTTPPerformer: HTTPPerformer {
+open class NetswiftHTTPPerformer: HTTPPerformer {
     
     private let session: NetswiftSession
     
@@ -17,17 +17,17 @@ public final class NetswiftHTTPPerformer: HTTPPerformer {
         self.session = session
     }
     
-    public func perform(_ request: URLRequest, completion: @escaping (NetswiftResult<Data?>) -> Void) -> NetswiftTask {
+    open func perform(_ request: URLRequest, completion: @escaping (NetswiftResult<Data?>) -> Void) -> NetswiftTask {
         return session.perform(request) { response in
             completion(self.validate(response))
         }
     }
     
-    public func perform(_ request: URLRequest, waitUpTo timeOut: DispatchTime = .now() + .seconds(5), completion: @escaping (NetswiftResult<Data?>) -> Void) -> NetswiftTask {
+    open func perform(_ request: URLRequest, waitUpTo timeOut: DispatchTime = .now() + .seconds(5), completion: @escaping (NetswiftResult<Data?>) -> Void) -> NetswiftTask {
         let dispatchGroup = DispatchGroup()
         
         if dispatchGroup.wait(timeout: timeOut) == .timedOut {
-            completion(.failure(.timedOut))
+            completion(.failure(.init(category: .timedOut, payload: nil)))
         }
         
         dispatchGroup.enter()
@@ -41,9 +41,9 @@ public final class NetswiftHTTPPerformer: HTTPPerformer {
     private func validate(_ response: NetswiftHTTPResponse) -> NetswiftResult<Data?> {
         guard let statusCode = response.statusCode else {
             guard let error = response.error else {
-                return .failure(.unknown(payload: response.data))
+                return .failure(.init(category: .unknown, payload: response.data))
             }
-            return .failure(.generic(error: error))
+            return .failure(.init(category: .generic(error: error), payload: response.data))
         }
         
         switch statusCode {
@@ -51,34 +51,34 @@ public final class NetswiftHTTPPerformer: HTTPPerformer {
             return .success(response.data)
 
         case 400:
-            return .failure(.requestError)
+            return .failure(.init(category: .requestError, payload: response.data))
 
         case 401:
-            return .failure(.notAuthenticated)
+            return .failure(.init(category: .notAuthenticated, payload: response.data))
 
         case 402:
-            return .failure(.paymentRequired(payload: response.data))
+            return .failure(.init(category: .paymentRequired, payload: response.data))
 
         case 403:
-            return .failure(.notPermitted)
+            return .failure(.init(category: .notPermitted, payload: response.data))
 
         case 404:
-            return .failure(.resourceNotFound(error: response.error, payload: response.data))
+            return .failure(.init(category: .resourceNotFound, payload: response.data))
 
         case 405:
-            return .failure(.methodNotAllowed)
+            return .failure(.init(category: .methodNotAllowed, payload: response.data))
 
         case 412:
-            return .failure(.preconditionFailed)
+            return .failure(.init(category: .preconditionFailed, payload: response.data))
 
         case 429:
-            return .failure(.tooManyRequests)
+            return .failure(.init(category: .tooManyRequests, payload: response.data))
 
         case 500:
-            return .failure(.serverError(payload: response.data))
+            return .failure(.init(category: .serverError, payload: response.data))
 
         default:
-            return .failure(.unknown(payload: response.data))
+            return .failure(.init(category: .unknown, payload: response.data))
         }
     }
 }


### PR DESCRIPTION
## [0.3.0 (20200225)]
### Changed
- `NetswiftError` has been refactored to always keep track of a network task's response payload, if any is available.
- `NetswiftRequest` are now given a chance to intercept and handle a `NetswiftError` when performed.

### Fixed
- Access control levels for  `NetswiftHTTPPerformer` and `NetswiftPerformer` have been set to `open` to allow for overriding and extending.