### PR TITLE
💥 Add requirement for requests with deadlines (time-out)

### DIFF
--- a/Example/Netswift/API/API.swift
+++ b/Example/Netswift/API/API.swift
@@ -19,8 +19,8 @@ struct API {
     }
     
     /// Convenience bridge function between NetswiftRequestPerformable & NetswiftPerformer
-    fileprivate func perform<T: NetswiftRequest>(_ request: T, _ handler: @escaping NetswiftHandler<T.Response>) -> NetswiftTask? {
-        return performer.perform(request, handler: handler)
+    fileprivate func perform<T: NetswiftRequest>(_ request: T, deadline: DispatchTime? = nil, _ handler: @escaping NetswiftHandler<T.Response>) -> NetswiftTask? {
+        return performer.perform(request, deadline: deadline, handler: handler)
     }
 
     @available(iOS 15, *)
@@ -32,6 +32,10 @@ struct API {
 extension NetswiftRequestPerformable {
     @discardableResult func perform(_ handler: @escaping NetswiftHandler<Self.Response>) -> NetswiftTask? {
         return API.shared.perform(self, handler)
+    }
+    
+    @discardableResult func perform(deadline: DispatchTime, _ handler: @escaping NetswiftHandler<Self.Response>) -> NetswiftTask? {
+        return API.shared.perform(self, deadline: deadline, handler)
     }
 
     @available(iOS 15, *)

--- a/Example/Netswift/JSONTodosTableViewController.swift
+++ b/Example/Netswift/JSONTodosTableViewController.swift
@@ -14,7 +14,6 @@ class JSONTodosTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.rightBarButtonItem = self.editButtonItem
         
         API.JSONPlaceholder.getAll.perform { result in
             self.todos = result.value
@@ -27,12 +26,10 @@ class JSONTodosTableViewController: UITableViewController {
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
         return 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
         return todos?.count ?? 0
     }
     

--- a/Sources/Netswift/Core/NetswiftHTTPMethod.swift
+++ b/Sources/Netswift/Core/NetswiftHTTPMethod.swift
@@ -16,6 +16,7 @@ public enum NetswiftHTTPMethod: String, CustomStringConvertible {
     case options = "OPTIONS"
     case put = "PUT"
     case patch = "PATCH"
+    case head = "HEAD"
     
     public var description: String {
         return self.rawValue

--- a/Sources/Netswift/Core/NetswiftHTTPResponse.swift
+++ b/Sources/Netswift/Core/NetswiftHTTPResponse.swift
@@ -10,14 +10,14 @@ import Foundation
 
 /// Convenience wrapper for URLResponses
 public struct NetswiftHTTPResponse {
-    let data: Data?
-    var statusCode: Int? {
+    public let data: Data?
+    public var statusCode: Int? {
         return (URLResponse as? HTTPURLResponse)?.statusCode
     }
-    let URLResponse: URLResponse?
-    let error: Swift.Error?
+    public let URLResponse: URLResponse?
+    public let error: Swift.Error?
 
-    init(data: Data?, response: URLResponse?, error: Swift.Error?) {
+    public  init(data: Data?, response: URLResponse?, error: Swift.Error?) {
         self.data = data
         self.URLResponse = response
         self.error = error

--- a/Sources/Netswift/Core/NetswiftNetworkPerformer.swift
+++ b/Sources/Netswift/Core/NetswiftNetworkPerformer.swift
@@ -17,7 +17,12 @@ public protocol NetswiftNetworkPerformer {
      Performs all the necessary work a NetswiftRequest defines in order to generate a `NetswiftResult` that either succeeds or fails.
      - parameter request: `NetswiftRequest` of specific type
      - parameter handler: A completion block that takes in a `NetswiftResult` that either contains a value of type `NetswiftRequest.Response` or an error of type `NetswiftError`
+     - returns: An optional `NetswiftTask` which can be used for further management of the ongoing request.
      */
+    func perform<Request: NetswiftRequest>(_ request: Request,
+                                           deadline: DispatchTime?,
+                                           handler: @escaping NetswiftHandler<Request.Response>) -> NetswiftTask?
+    
     func perform<T: NetswiftRequest>(_ request: T, handler: @escaping NetswiftHandler<T.Response>) -> NetswiftTask?
 
     /**

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -204,7 +204,7 @@ public extension NetswiftRequest where Self: NetswiftRoute {
      
      Use during debugging:
      
-     `po print(<urlRequest>.curl)`
+     `po print(<request>.curl)`
      */
     var curl: String {
         guard let request = serialise().value,

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -195,3 +195,43 @@ public extension NetswiftRequest {
         return .failure(.init(category: .responseCastingError, payload: any as? Data))
     }
 }
+
+// MARK: - cURL
+
+public extension NetswiftRequest where Self: NetswiftRoute {
+    /**
+     Returns a cURL command representation of this request.
+     
+     Use during debugging:
+     
+     `po print(<urlRequest>.curl)`
+     */
+    var curl: String {
+        guard let request = serialise().value,
+              let url = request.url else { return "Unable to serialise request" }
+        
+        var baseCommand = #"curl "\#(url.absoluteString)""#
+        
+        if method == .head {
+            baseCommand += " --head"
+        }
+        
+        var command = [baseCommand]
+        
+        if method != .get && method != .head {
+            command.append("-X \(method)")
+        }
+        
+        if let headers = request.allHTTPHeaderFields {
+            for (key, value) in headers where key != "Cookie" {
+                command.append("-H '\(key): \(value)'")
+            }
+        }
+        
+        if let data = request.httpBody, let body = String(data: data, encoding: .utf8) {
+            command.append("-d '\(body)'")
+        }
+        
+        return command.joined(separator: " \\\n\t")
+    }
+}

--- a/Sources/Netswift/Core/NetswiftRequestPerformable.swift
+++ b/Sources/Netswift/Core/NetswiftRequestPerformable.swift
@@ -14,10 +14,22 @@ public protocol NetswiftRequestPerformable: NetswiftRequest {
     /**
      Performs the request with its own, self-defined NetswiftNetworkPerformer
      - parameter handler: Called when the request returns
+     - returns: An optional `NetswiftTask` which can be used for further management of the ongoing request.
      */
     func perform(_ handler: @escaping NetswiftHandler<Self.Response>) -> NetswiftTask?
     
     /**
+
+	/**
+     Performs the request with its own, self-defined NetworkPerformer, with a deadline.
+     - parameters:
+        - handler: Called when the request returns
+        - timeOut: Amount of time before the request is considered as having timed-out.
+     - returns: An optional `NetswiftTask` which can be used for further management of the ongoing request.
+     */
+    func perform(_ handler: @escaping NetswiftHandler<Self.Response>, timeOutAfter timeOut: DispatchTime) -> NetswiftTask?
+	
+	/**
      Performs the request with its own, self-defined NetswiftNetworkPerformer, asynchronously.
      - returns: The result of this request, either a failure with an error, or a success with an instance of type `Self.Response`.
      */

--- a/Sources/Netswift/Core/NetswiftRequestPerformable.swift
+++ b/Sources/Netswift/Core/NetswiftRequestPerformable.swift
@@ -19,17 +19,15 @@ public protocol NetswiftRequestPerformable: NetswiftRequest {
     func perform(_ handler: @escaping NetswiftHandler<Self.Response>) -> NetswiftTask?
     
     /**
-
-	/**
      Performs the request with its own, self-defined NetworkPerformer, with a deadline.
      - parameters:
         - handler: Called when the request returns
-        - timeOut: Amount of time before the request is considered as having timed-out.
+        - deadline: Amount of time before the request is considered as having timed-out.
      - returns: An optional `NetswiftTask` which can be used for further management of the ongoing request.
      */
-    func perform(_ handler: @escaping NetswiftHandler<Self.Response>, timeOutAfter timeOut: DispatchTime) -> NetswiftTask?
-	
-	/**
+    func perform(deadline: DispatchTime, _ handler: @escaping NetswiftHandler<Self.Response>) -> NetswiftTask?
+    
+    /**
      Performs the request with its own, self-defined NetswiftNetworkPerformer, asynchronously.
      - returns: The result of this request, either a failure with an error, or a success with an instance of type `Self.Response`.
      */


### PR DESCRIPTION
`NetswiftRequestPerformable` now has an additional requirement so that they can be performed with time-out of your choice.

Additionally, some further changes were done:
### Added
- `NetswiftHTTPMethod.head`, a convenience accessor for `HEAD` http methods.
- `NetswiftRequest.curl`, a convenience `cURL` string generator for any request.

### Changed
- Made variables & constructor under `NetswiftHTTPResponse` public.