### PR TITLE
Release/v0.7.0 - Platforms!

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,16 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Netswift",
+    platforms: [
+        .iOS(.v11),
+        .macOS(.v11),
+        .tvOS(.v15),
+        .watchOS(.v8)
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Sources/Netswift/Core/GenericScheme.swift
+++ b/Sources/Netswift/Core/GenericScheme.swift
@@ -11,10 +11,29 @@ import Foundation
 /**
  A generic, all-purpose scheme provider.
  */
-public enum GenericScheme: String {
-    case http = "http://"
-    case https = "https://"
-    case ftp = "ftp://"
-    case ldap = "ldap://"
-    case mailto = "mailto:"
+public enum NetswiftScheme {
+    
+    case http
+    case https
+    case ftp
+    case ldap
+    case mailto
+    case custom(scheme: String)
+    
+    public var value: String {
+        switch self {
+        case .http:
+            return "http"
+        case .https:
+            return "https"
+        case .ftp:
+            return "ftp"
+        case .ldap:
+            return "ldap"
+        case .mailto:
+            return "mailto"
+        case .custom(let scheme):
+            return scheme
+        }
+    }
 }

--- a/Sources/Netswift/Core/HTTPPerformer.swift
+++ b/Sources/Netswift/Core/HTTPPerformer.swift
@@ -26,7 +26,7 @@ public protocol HTTPPerformer {
      - parameter request: Any URLRequest that has already been initialised and configured.
      - returns: The Requests result
      */
-    @available(iOS 15, *)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func perform(_ request: URLRequest) async -> NetswiftResult<Data?>
     
     /**
@@ -47,6 +47,6 @@ public protocol HTTPPerformer {
      - parameter deadline: The maximum amount of seconds before the task is considered as timed-out, forcing a call to completion with a `.timedOut` NetswiftError.
      - returns: The Requests result
      */
-    @available(iOS 15, *)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func perform(_ request: URLRequest, deadline: DispatchTime) async -> NetswiftResult<Data?>
 }

--- a/Sources/Netswift/Core/NetswiftAuthorizationType.swift
+++ b/Sources/Netswift/Core/NetswiftAuthorizationType.swift
@@ -10,15 +10,27 @@ import Foundation
 /**
  An Authorization HTTP Request header field.
  */
-public enum NetswiftAuthorizationType {
+public enum NetswiftAuthorizationType: Hashable {
     
     /// Bearer \<token\>
     case bearer(token: String)
+    
+    /// Basic \<token\>
+    case basic(token: String)
+    
+    /// \<Header\> \<token\>
+    case custom(header: String, token: String)
     
     var rawValue: String {
         switch self {
         case .bearer(let token):
             return "Bearer \(token)"
+            
+        case let .basic(token):
+            return "Basic \(token)"
+            
+        case let .custom(header, token):
+            return "\(header) \(token)"
         }
     }
 }

--- a/Sources/Netswift/Core/NetswiftError/NetswiftError+Category.swift
+++ b/Sources/Netswift/Core/NetswiftError/NetswiftError+Category.swift
@@ -60,6 +60,10 @@ public extension NetswiftError {
         /// The user has sent too many requests in a given amount of time
         case tooManyRequests
         
+        /// The server understands the content type of the request entity, and the syntax of the request entity is correct, but it was unable to process the contained instructions.
+        /// - warning: The client should not repeat this request without modification.
+        case unprocessableEntity
+        
         /// A generic error with a provided error object
         case generic(error: Swift.Error)
         
@@ -102,6 +106,8 @@ public extension NetswiftError {
                 return "Too Many Requests"
             case .unexpectedResponseError:
                 return "Unexpected Response"
+            case .unprocessableEntity:
+                return "Unprocessable Entity"
             case .unknown:
                 return "Unknown"
             }
@@ -127,6 +133,8 @@ extension NetswiftError.Category {
             return 405
         case .preconditionFailed:
             return 412
+        case .unprocessableEntity:
+            return 422
         case .tooManyRequests:
             return 429
         case .serverError:
@@ -171,6 +179,8 @@ extension NetswiftError.Category {
             return .methodNotAllowed
         case 412:
             return .preconditionFailed
+        case 422:
+            return .unprocessableEntity
         case 429:
             return .tooManyRequests
         case 500:

--- a/Sources/Netswift/Core/NetswiftError/NetswiftError.swift
+++ b/Sources/Netswift/Core/NetswiftError/NetswiftError.swift
@@ -30,20 +30,21 @@ extension NetswiftError: Equatable {
     public static func == (lhs: NetswiftError, rhs: NetswiftError) -> Bool {
         switch (lhs.category, rhs.category) {
         case (.requestSerialisationError, .requestSerialisationError),
-             (.requestError, .requestError),
-             (.unexpectedResponseError, .unexpectedResponseError),
-             (.noResponseError, .noResponseError),
-             (.responseCastingError, .responseCastingError),
-             (.notAuthenticated, .notAuthenticated),
-             (.notPermitted, .notPermitted),
-             (.timedOut, .timedOut),
-             (.preconditionFailed, .preconditionFailed),
-             (.methodNotAllowed, .methodNotAllowed),
-             (.tooManyRequests, .tooManyRequests),
-             (.serverError, .serverError),
-             (.paymentRequired, .paymentRequired),
-             (.resourceNotFound, .resourceNotFound),
-             (.resourceRemoved, .resourceRemoved):
+            (.requestError, .requestError),
+            (.unexpectedResponseError, .unexpectedResponseError),
+            (.noResponseError, .noResponseError),
+            (.responseCastingError, .responseCastingError),
+            (.notAuthenticated, .notAuthenticated),
+            (.notPermitted, .notPermitted),
+            (.timedOut, .timedOut),
+            (.preconditionFailed, .preconditionFailed),
+            (.methodNotAllowed, .methodNotAllowed),
+            (.tooManyRequests, .tooManyRequests),
+            (.serverError, .serverError),
+            (.paymentRequired, .paymentRequired),
+            (.resourceNotFound, .resourceNotFound),
+            (.resourceRemoved, .resourceRemoved),
+            (.unprocessableEntity, .unprocessableEntity):
             return true
             
         case (.responseDecodingError(let lhsError), .responseDecodingError(let rhsError)):
@@ -90,6 +91,8 @@ extension NetswiftError: CustomDebugStringConvertible {
             return "A request method is not supported for the requested resource"
         case .tooManyRequests:
             return "The user has sent too many requests in a given amount of time"
+        case .unprocessableEntity:
+            return "The server understands the content type of the request entity, and the syntax of the request entity is correct, but it was unable to process the contained instructions. The client should not repeat this request without modification."
         case .generic(let error):
             return error.localizedDescription
         case .unknown:

--- a/Sources/Netswift/Core/NetswiftHTTPResponse.swift
+++ b/Sources/Netswift/Core/NetswiftHTTPResponse.swift
@@ -17,7 +17,9 @@ public struct NetswiftHTTPResponse {
     public let URLResponse: URLResponse?
     public let error: Swift.Error?
 
-    public  init(data: Data?, response: URLResponse?, error: Swift.Error?) {
+    public init(data: Data?,
+                response: URLResponse?,
+                error: Swift.Error? = nil) {
         self.data = data
         self.URLResponse = response
         self.error = error

--- a/Sources/Netswift/Core/NetswiftHeaders.swift
+++ b/Sources/Netswift/Core/NetswiftHeaders.swift
@@ -1,0 +1,68 @@
+//
+//  NetswiftHeaders.swift
+//  
+//
+//  Created by Dorian on 25/01/2023.
+//
+
+import Foundation
+
+public struct NetswiftHeaders {
+    
+    public init(
+        authorization: NetswiftAuthorizationType? = nil,
+        accept: MimeType = .json,
+        contentType: MimeType = .json,
+        additionalHeaders: Set<RequestHeader> = []
+    ) {
+        self.authorization = authorization
+        self.accept = accept
+        self.contentType = contentType
+        self.additionalHeaders = additionalHeaders
+    }
+    
+    /**
+     Specifies what type of authentication a request should use
+     
+     - important: Defaults to `nil`
+     */
+    public var authorization: NetswiftAuthorizationType?
+    
+    /**
+     Specifies what type of content a request expects back.
+     
+     - important: Defaults to `.json`
+     */
+    public var accept: MimeType
+    
+    /**
+     Specifies what type of content a request emits.
+     
+     - important: Defaults to `.json`
+     */
+    public var contentType: MimeType
+    
+    /**
+     Specifies additional HTTP headers to use for a request.
+     
+     These headers will be concatenated with any other already specified header (such as Content-Type or Accept).
+     
+     - note: Set **Content-Type** or **Accept** headers through `contentType` or `accept` protocol vars.
+     - important: Defaults to empty array.
+     */
+    public var additionalHeaders: Set<RequestHeader> = []
+    
+    /**
+     A set constructed from all headers defined in this object.
+     
+     - warning: Headers defined under `additionalHeaders` are overwritten by existing struct members such as `accept`, `contentType` or `authorization`.
+     */
+    public var all: Set<RequestHeader> {
+        var all = additionalHeaders
+        all.update(with: .accept(accept))
+        all.update(with: .contentType(contentType))
+        if let authorization { all.update(with: .authorization(authorization)) }
+        
+        return all
+    }
+}

--- a/Sources/Netswift/Core/NetswiftNetworkPerformer.swift
+++ b/Sources/Netswift/Core/NetswiftNetworkPerformer.swift
@@ -28,6 +28,15 @@ public protocol NetswiftNetworkPerformer {
      - parameter request: `NetswiftRequest` of specific type
      - returns: An asynchronous `NetswiftResult` with the type specified within the `NetswiftRequest` argument.
      */
-    @available(iOS 15, *)
-    func perform<T: NetswiftRequest>(_ request: T) async -> NetswiftResult<T.Response>
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func perform<Request: NetswiftRequest>(_ request: Request) async -> NetswiftResult<Request.Response>
+    
+    /**
+     Performs all the necessary work a NetswiftRequest defines in order to generate a `NetswiftResult` that either succeeds or fails.
+     - parameter request: `NetswiftRequest` of specific type
+     - throws: Any networking-related error.
+     - returns: An asynchronous `Response` type.
+     */
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func perform<Request: NetswiftRequest>(_ request: Request) async throws -> Request.Response
 }

--- a/Sources/Netswift/Core/NetswiftRequest.swift
+++ b/Sources/Netswift/Core/NetswiftRequest.swift
@@ -18,21 +18,9 @@ public protocol NetswiftRequest {
     associatedtype IncomingType = Data
     
     /**
-     Specifies additional HTTP headers to use for this request.
-     
-     These headers will be concatenated with any other already specified header (such as Content-Type or Accept).
-     
-     - note: Set Content-Type or Accept headers through `contentType` or `accept` protocol vars.
-     - important: Defaults to empty array.
+     Specifies HTTP headers to use for this request.
      */
-    var additionalHeaders: [RequestHeader] { get }
-    
-    /**
-     Specifies what type of content this request emits.
-     
-     - important: Defaults to `.json`
-     */
-    var contentType: MimeType { get }
+    var headers: NetswiftHeaders { get }
     
     /**
      Specifies which encoder should be used for encoding this request's body
@@ -47,13 +35,6 @@ public protocol NetswiftRequest {
      - important: Returns `nil` by default
      */
     func body(encodedBy encoder: NetswiftEncoder?) throws -> Data?
-    
-    /**
-     Specifies what type of content this request expects back.
-     
-     - important: Defaults to `.json`
-     */
-    var accept: MimeType { get }
     
     /**
      Tries to generate a URLRequest given the specific internals of the NetswiftRequest. Might fail.
@@ -93,12 +74,8 @@ public protocol NetswiftRequest {
 }
 
 public extension NetswiftRequest {
-    var additionalHeaders: [RequestHeader] {
-        return []
-    }
-    
-    var contentType: MimeType {
-        return .json
+    var headers: NetswiftHeaders {
+        return .init()
     }
     
     var bodyEncoder: NetswiftEncoder? {
@@ -107,10 +84,6 @@ public extension NetswiftRequest {
     
     func body(encodedBy encoder: NetswiftEncoder?) -> Data? {
         return nil
-    }
-    
-    var accept: MimeType {
-        return .json
     }
     
     func intercept(_ error: NetswiftError) -> NetswiftResult<Response> {
@@ -125,11 +98,6 @@ public extension NetswiftRequest where Self: NetswiftRoute {
         var request = URLRequest(url: self.url)
         request.setHTTPMethod(self.method)
         
-        var headers = additionalHeaders
-        
-        headers.append(.contentType(contentType))
-        headers.append(.accept(accept))
-        
         do {
             if let encoder = bodyEncoder {
                 request.httpBody = try body(encodedBy: encoder)
@@ -138,7 +106,7 @@ public extension NetswiftRequest where Self: NetswiftRoute {
             return .failure(.init(.requestSerialisationError))
         }
         
-        request.addHeaders(headers)
+        request.addHeaders(headers.all)
         
         return .success(request)
     }
@@ -167,6 +135,12 @@ public extension NetswiftRequest where IncomingType == Data, Response == String 
             return .failure(.init(category: .unexpectedResponseError, payload: incomingData))
         }
         return .success(string)
+    }
+}
+
+public extension NetswiftRequest where IncomingType == Data, Response == Data {
+    func deserialise(_ incomingData: Data) -> NetswiftResult<Response> {
+        .success(incomingData)
     }
 }
 

--- a/Sources/Netswift/Core/NetswiftRoute.swift
+++ b/Sources/Netswift/Core/NetswiftRoute.swift
@@ -20,7 +20,7 @@ public protocol NetswiftRoute {
      Which scheme to use
      - note: HTTPS by default
      */
-    var scheme: String { get }
+    var scheme: NetswiftScheme { get }
     
     /**
      The host
@@ -28,6 +28,15 @@ public protocol NetswiftRoute {
      Example: `google`
      */
     var host: String? { get }
+    
+    /**
+     The port
+     
+     Example: `80`
+     
+     - note: `80` by default
+     */
+    var port: Int { get }
     
     /**
      The specific resource on the host
@@ -58,7 +67,7 @@ public protocol NetswiftRoute {
     /**
      A fully qualified URL
      
-     - note: Uses the following format by default: `<scheme><host><path><query><fragment>`
+     - note: Uses the following format by default: `<scheme><host><port><path><query><fragment>`
      */
     var url: URL { get }
 }
@@ -67,8 +76,12 @@ public protocol NetswiftRoute {
 
 public extension NetswiftRoute {
     
-    var scheme: String {
-        return GenericScheme.https.rawValue
+    var scheme: NetswiftScheme {
+        return .https
+    }
+    
+    var port: Int {
+        return 80
     }
     
     var path: String? {
@@ -88,13 +101,13 @@ public extension NetswiftRoute {
     }
     
     var url: URL {
-        let scheme = self.scheme
-        let host = (self.host ?? "").addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
-        let path = (self.path ?? "").addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
-        let query = (self.query ?? "").addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
-        var fragment = ""
-        if let unwrappedFragment = self.fragment { fragment = "#\(unwrappedFragment)" }
-        fragment = fragment.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
-        return URL(string: "\(scheme)\(host)\(path)\(query)\(fragment)")!
+        var components = URLComponents()
+        components.scheme = self.scheme.value
+        components.host = self.host
+        components.port = self.port == 80 ? nil : self.port // Omit including port when it's 80
+        components.path = self.path ?? "/"
+        components.query = self.query
+        components.fragment = self.fragment
+        return components.url!
     }
 }

--- a/Sources/Netswift/Core/NetswiftSession.swift
+++ b/Sources/Netswift/Core/NetswiftSession.swift
@@ -14,7 +14,7 @@ public protocol NetswiftSession {
     
     func perform(_ urlRequest: URLRequest, handler: @escaping RequestHandler) -> NetswiftTask
 
-    @available(iOS 15, *)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     func perform(_ urlRequest: URLRequest) async -> NetswiftHTTPResponse
 }
 
@@ -32,11 +32,11 @@ extension URLSession: NetswiftSession {
     }
 
     /// Asynchronous data call made via NetswiftSession Protocol
-    @available(iOS 15, *)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func perform(_ urlRequest: URLRequest) async -> NetswiftHTTPResponse {
         do {
             let (data, response) = try await data(for: urlRequest)
-            return NetswiftHTTPResponse(data: data, response: response, error: nil)
+            return NetswiftHTTPResponse(data: data, response: response)
         } catch {
             return NetswiftHTTPResponse(data: nil, response: nil, error: error)
         }

--- a/Sources/Netswift/Core/RequestHeader.swift
+++ b/Sources/Netswift/Core/RequestHeader.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  An HTTP Request header field. Defines its identifier & its value.
  */
-public enum RequestHeader {
+public enum RequestHeader: Hashable {
     /// Content-Type
     case contentType(MimeType)
     

--- a/Sources/Netswift/Core/URLRequestExtension.swift
+++ b/Sources/Netswift/Core/URLRequestExtension.swift
@@ -14,13 +14,13 @@ public extension URLRequest {
         self.httpMethod = method.rawValue
     }
     
-    mutating func setHeaders(_ headers: [RequestHeader]) {
+    mutating func setHeaders(_ headers: Set<RequestHeader>) {
         headers.forEach {
             setValue($0.value, forHTTPHeaderField: $0.key)
         }
     }
     
-    mutating func addHeaders(_ headers: [RequestHeader]) {
+    mutating func addHeaders(_ headers: Set<RequestHeader>) {
         headers.forEach {
             addValue($0.value, forHTTPHeaderField: $0.key)
         }

--- a/Sources/Netswift/NetswiftHTTPPerformer.swift
+++ b/Sources/Netswift/NetswiftHTTPPerformer.swift
@@ -23,7 +23,7 @@ open class NetswiftHTTPPerformer: HTTPPerformer {
         }
     }
 
-    @available(iOS 15, *)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     open func perform(_ request: URLRequest) async -> NetswiftResult<Data?> {
         return await validate(session.perform(request))
     }
@@ -43,7 +43,7 @@ open class NetswiftHTTPPerformer: HTTPPerformer {
         }
     }
 
-    @available(iOS 15, *)
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     open func perform(_ request: URLRequest, deadline: DispatchTime = .now() + .seconds(5)) async -> NetswiftResult<Data?> {
         await withCheckedContinuation{ continuation in
             let dispatchGroup = DispatchGroup()

--- a/Sources/Netswift/NetswiftPerformer.swift
+++ b/Sources/Netswift/NetswiftPerformer.swift
@@ -17,14 +17,15 @@ open class NetswiftPerformer: NetswiftNetworkPerformer {
     }
     
     @discardableResult
-    open func perform<Request: NetswiftRequest>(_ request: Request,
+    public func perform<Request: NetswiftRequest>(_ request: Request,
                                                 deadline: DispatchTime? = nil,
                                                 handler: @escaping NetswiftHandler<Request.Response>) -> NetswiftTask? {
         guard let deadline = deadline else {
             return perform(request, handler: handler)
         }
         switch request.serialise() {
-        case .success(let url):
+        case .success(var url):
+            hook(into: &url)
             return self.requestPerformer.perform(url, deadline: deadline) { response in
                 handler(Self.validateResponse(response, from: request))
             }
@@ -36,10 +37,11 @@ open class NetswiftPerformer: NetswiftNetworkPerformer {
     }
     
     @discardableResult
-    open func perform<Request: NetswiftRequest>(_ request: Request,
+    public func perform<Request: NetswiftRequest>(_ request: Request,
                                                 handler: @escaping NetswiftHandler<Request.Response>) -> NetswiftTask? {
         switch request.serialise() {
-        case .success(let url):
+        case .success(var url):
+            hook(into: &url)
             return self.requestPerformer.perform(url) { response in
                 handler(Self.validateResponse(response, from: request))
             }
@@ -50,15 +52,39 @@ open class NetswiftPerformer: NetswiftNetworkPerformer {
         return nil
     }
     
-    @available(iOS 15, *)
-    open func perform<Request: NetswiftRequest>(_ request: Request) async -> NetswiftResult<Request.Response> {
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func perform<Request: NetswiftRequest>(_ request: Request) async -> NetswiftResult<Request.Response> {
         switch request.serialise() {
-        case .success(let url):
+        case .success(var url):
+            hook(into: &url)
             return await Self.validateResponse(requestPerformer.perform(url),
                                           from: request)
         case .failure(let error):
             return .failure(error)
         }
+    }
+    
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    public func perform<Request: NetswiftRequest>(_ request: Request) async throws -> Request.Response {
+        switch request.serialise() {
+        case .success(var url):
+            hook(into: &url)
+            let result = await Self.validateResponse(requestPerformer.perform(url),
+                                                     from: request)
+            switch result {
+            case let .success(response): return response
+            case let .failure(error): throw error
+            }
+        case .failure(let error):
+            throw error
+        }
+    }
+    
+    /**
+     Override this function to perform extra configuration on the outgoing URLRequest, before it is sent out.
+     */
+    open func hook(into urlRequest: inout URLRequest) {
+        // overridable, empty default
     }
     
     private static func validateResponse<Request: NetswiftRequest>(_ result: NetswiftResult<Data?>,


### PR DESCRIPTION
## Added
- Support for macOS 12.0, iOS 15.0, tvOS 15.0 & watchOS 8.0
- NetswiftHeaders type, consolidates headers definition
- `Basic token` & custom Auth types
- `hook(into: URLRequest)` on `NetswiftPerformer`
- `port` can now be specified on routes
- `scheme` now uses `NetswiftScheme` type, with support for custom schemes
- Added 422 status code handling

## Changed
- URL instantiation now uses `URLComponents`
- Request Headers are now handled as a `Set`